### PR TITLE
ドラッグ＆ドロップでMenuの順番を並び替える機能を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ git_source(:github) {|repo| "https://github.com/#{repo}.git" }
 
 ruby "3.0.0"
 
+gem "acts_as_list"
 gem "bootsnap", ">= 1.4.4", require: false
 gem "hamlit-rails"
 gem "jbuilder", "~> 2.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    acts_as_list (1.0.3)
+      activerecord (>= 4.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
@@ -302,6 +304,7 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
+  acts_as_list
   bootsnap (>= 1.4.4)
   byebug
   capybara

--- a/README.md
+++ b/README.md
@@ -2,4 +2,7 @@
 
 主にこれから実装する機能の動きの確認、振り返りなどに使用します。
 
+1. [【スマホ対応】ドラッグ＆ドロップで連番の並び替えをする。「acts_as_list」+「Sortable.js」](https://www.webya-wagai.jp/articles/1)
+   [![Image from Gyazo](https://i.gyazo.com/ad9b17cb6e231e801669df9a4741829e.gif)](https://gyazo.com/ad9b17cb6e231e801669df9a4741829e)
+
 [web屋 和賀井](https://webya-wagai.jp/)

--- a/app/controllers/api/menu/positions_controller.rb
+++ b/app/controllers/api/menu/positions_controller.rb
@@ -1,4 +1,4 @@
-class Api::MenusController < ApplicationController
+class Api::Menu::PositionsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def update

--- a/app/controllers/api/menus_controller.rb
+++ b/app/controllers/api/menus_controller.rb
@@ -1,0 +1,9 @@
+class Api::MenusController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def update
+    menu = Menu.find_by!(position: params[:from].to_i + 1)
+    menu.update!(position: params[:to].to_i + 1) # SortableのnewInbexは0から始まるから
+    head :ok
+  end
+end

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -3,7 +3,7 @@ class MenusController < ApplicationController
 
   # GET /menus or /menus.json
   def index
-    @menus = Menu.all
+    @menus = Menu.sorted
   end
 
   # GET /menus/1 or /menus/1.json

--- a/app/javascript/packs/views/menus/index.js
+++ b/app/javascript/packs/views/menus/index.js
@@ -1,0 +1,10 @@
+import Sortable from 'sortablejs';
+
+document.addEventListener('turbolinks:load', function () {
+    const el = document.getElementById('js-sortable-menus');
+    new Sortable(el, {
+        handle: "i.handle",
+        axis: 'y',
+        animation: 150,
+    });
+});

--- a/app/javascript/packs/views/menus/index.js
+++ b/app/javascript/packs/views/menus/index.js
@@ -9,7 +9,7 @@ $(document).on('turbolinks:load', function () {
         animation: 150,
         onUpdate: function (evt) {
             return $.ajax({
-                url: `/api/menus/${evt.oldIndex}`,
+                url: `/api/menu/positions/${evt.oldIndex}`,
                 type: 'patch',
                 data: {
                     from: evt.oldIndex,

--- a/app/javascript/packs/views/menus/index.js
+++ b/app/javascript/packs/views/menus/index.js
@@ -1,10 +1,21 @@
 import Sortable from 'sortablejs';
+require("jquery")
 
-document.addEventListener('turbolinks:load', function () {
+$(document).on('turbolinks:load', function () {
     const el = document.getElementById('js-sortable-menus');
     new Sortable(el, {
         handle: "i.handle",
         axis: 'y',
         animation: 150,
+        onUpdate: function (evt) {
+            return $.ajax({
+                url: `/api/menus/${evt.oldIndex}`,
+                type: 'patch',
+                data: {
+                    from: evt.oldIndex,
+                    to: evt.newIndex
+                }
+            });
+        }
     });
 });

--- a/app/javascript/packs/views/menus/index.js
+++ b/app/javascript/packs/views/menus/index.js
@@ -1,5 +1,4 @@
 import Sortable from 'sortablejs';
-require("jquery")
 
 $(document).on('turbolinks:load', function () {
     const el = document.getElementById('js-sortable-menus');

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,4 +1,5 @@
 class Menu < ApplicationRecord
+  acts_as_list
   validates :title, presence: true, length: { maximum: 50 }
   validates :price, presence: true, numericality: { only_integer: true }
 end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -2,4 +2,6 @@ class Menu < ApplicationRecord
   acts_as_list
   validates :title, presence: true, length: { maximum: 50 }
   validates :price, presence: true, numericality: { only_integer: true }
+
+  scope :sorted, -> { order(position: :asc) }
 end

--- a/app/views/menus/index.html.haml
+++ b/app/views/menus/index.html.haml
@@ -1,17 +1,21 @@
+= javascript_pack_tag "views/menus/index", "data-turbolinks-track": "reload"
 %h1 Listing menus
 
 %table
   %thead
     %tr
+      %th
       %th Title
       %th Price
       %th
       %th
       %th
 
-  %tbody
+  %tbody#js-sortable-menus
     - @menus.each do |menu|
       %tr
+        %td
+          %i.handle ■
         %td= menu.title
         %td= menu.price
         %td= link_to "Show", menu

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
   resources :menus
 
   namespace :api do
-    resources :menus, only: [:update]
+    namespace :menu do
+      resources :positions, only: [:update]
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
   root to: "static_pages#index"
   resources :menus
+
+  namespace :api do
+    resources :menus, only: [:update]
+  end
 end

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,10 @@
 const { environment } = require('@rails/webpacker')
-
+// jqueryの設定
+const webpack = require('webpack')
+environment.plugins.prepend('Provide',
+    new webpack.ProvidePlugin({
+        $: 'jquery/src/jquery',
+        jQuery: 'jquery/src/jquery'
+    })
+)
 module.exports = environment

--- a/db/migrate/20210208190651_add_position_to_menu.rb
+++ b/db/migrate/20210208190651_add_position_to_menu.rb
@@ -1,6 +1,6 @@
 class AddPositionToMenu < ActiveRecord::Migration[6.1]
   def change
-    add_column :menus, :position, :integer
+    add_column :menus, :position, :integer, default: :id || 0
     add_index :menus, :position
   end
 end

--- a/db/migrate/20210208190651_add_position_to_menu.rb
+++ b/db/migrate/20210208190651_add_position_to_menu.rb
@@ -1,6 +1,6 @@
 class AddPositionToMenu < ActiveRecord::Migration[6.1]
   def change
-    add_column :menus, :position, :integer, default: :id || 0
+    add_column :menus, :position, :integer, null: false, default: :id || 0
     add_index :menus, :position
   end
 end

--- a/db/migrate/20210208190651_add_position_to_menu.rb
+++ b/db/migrate/20210208190651_add_position_to_menu.rb
@@ -1,0 +1,6 @@
+class AddPositionToMenu < ActiveRecord::Migration[6.1]
+  def change
+    add_column :menus, :position, :integer
+    add_index :menus, :position
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_08_181422) do
+ActiveRecord::Schema.define(version: 2021_02_08_190651) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 2021_02_08_181422) do
     t.integer "price", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "position"
+    t.index ["position"], name: "index_menus_on_position"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 2021_02_08_190651) do
     t.integer "price", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "position"
+    t.integer "position", null: false
     t.index ["position"], name: "index_menus_on_position"
   end
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.2.1",
+    "sortablejs": "^1.13.0",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.2.1",
+    "jquery": "^3.5.1",
     "sortablejs": "^1.13.0",
     "turbolinks": "^5.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6561,6 +6561,11 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
+sortablejs@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.13.0.tgz#3ab2473f8c69ca63569e80b1cd1b5669b51269e9"
+  integrity sha512-RBJirPY0spWCrU5yCmWM1eFs/XgX2J5c6b275/YyxFRgnzPhKl/TDeU2hNR8Dt7ITq66NRPM4UlOt+e5O4CFHg==
+
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3985,6 +3985,11 @@ jest-worker@^26.5.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jquery@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
+
 js-base64@^2.1.8:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
ドラッグ＆ドロップで順番を並び替え＆自動連番の処理を実装

# 実装課題
- [x] Menuモデルに`position`カラムを追加
- [x] acts_as_listの導入
- [x] SortableJSの導入
- [x] jqueryの導入
- [x] APIコントローラー作成
- [x] Ajax処理の実装

# 新規ライブラリ導入の理由(メリット)・背景・ドキュメント等
- acts_as_listの導入
- SortableJSの導入
- jqueryの導入

# UI変更

## 動きがある場合(GIF動画など)
<a href="https://gyazo.com/ad9b17cb6e231e801669df9a4741829e"><img src="https://i.gyazo.com/ad9b17cb6e231e801669df9a4741829e.gif" alt="Image from Gyazo" width="428"/></a>

# その他・備考
- 追加した`position`カラムに`unique index`を設定すると動かない。DBベースでuniqueキーを設定出来ないのは怖い。

# Fix、追加
#20 
#21 