### PR TITLE
Menuの並び替えjsをturbolinks:loadで呼び出すのをやめた

### DIFF
--- a/app/javascript/packs/views/menus/index.js
+++ b/app/javascript/packs/views/menus/index.js
@@ -1,11 +1,11 @@
 import Sortable from 'sortablejs';
 
-$(document).on('turbolinks:load', function () {
+$(function() {
     const el = document.getElementById('js-sortable-menus');
     new Sortable(el, {
         handle: "i.handle",
         axis: 'y',
-        animation: 150,
+        animation: 300,
         onUpdate: function (evt) {
             return $.ajax({
                 url: `/api/menu/positions/${evt.oldIndex}`,


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

# 概要
turbolinks:loadだと別のviewにもjsが引き継がれるので取り除いた